### PR TITLE
Add experimental web interface skeleton

### DIFF
--- a/web-app/README.md
+++ b/web-app/README.md
@@ -1,0 +1,17 @@
+# Gemini Web Application (Experimental)
+
+This directory contains a minimal proof-of-concept web interface for
+`@google/gemini-cli-core`.
+
+```
+web-app/
+  backend/   - Node.js backend for frontend (BFF)
+  frontend/  - React web client
+```
+
+The backend exposes a WebSocket API on `ws://localhost:3000` and serves the
+static frontend files. The frontend uses the protocol described in the project
+architecture to send chat messages and receive streaming updates.
+
+Both sub-projects are independent from the main monorepo build and are intended
+for experimentation only.

--- a/web-app/backend/package.json
+++ b/web-app/backend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "gemini-web-backend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/server.js",
+  "scripts": {
+    "start": "node dist/server.js",
+    "dev": "ts-node src/server.ts"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "ws": "^8.18.0",
+    "@google/gemini-cli-core": "../../packages/core"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3",
+    "ts-node": "^10.9.1"
+  }
+}

--- a/web-app/backend/src/server.ts
+++ b/web-app/backend/src/server.ts
@@ -1,0 +1,103 @@
+import express from 'express';
+import { createServer } from 'http';
+import { WebSocketServer } from 'ws';
+import { Config, AuthType, CoreToolScheduler, GeminiEventType, ServerGeminiStreamEvent, ToolConfirmationOutcome } from '@google/gemini-cli-core';
+import { v4 as uuidv4 } from 'uuid';
+
+function mapEvent(event: ServerGeminiStreamEvent) {
+  switch (event.type) {
+    case GeminiEventType.Content:
+      return { type: 'stream_update', payload: { textChunk: event.value } };
+    case GeminiEventType.ToolCallConfirmation:
+      return {
+        type: 'tool_request',
+        payload: {
+          callId: event.value.request.callId,
+          toolName: event.value.request.name,
+          description: '',
+          details: event.value.details,
+        },
+      };
+    case GeminiEventType.Error:
+      return { type: 'error', payload: { message: event.value.error.message } };
+    default:
+      return { type: 'debug', payload: event };
+  }
+}
+
+async function createSession() {
+  const sessionId = uuidv4();
+  const config = new Config({
+    sessionId,
+    targetDir: process.cwd(),
+    debugMode: false,
+    model: 'gemini-1.0-pro',
+    cwd: process.cwd(),
+  });
+  await config.initialize();
+  await config.refreshAuth(process.env.GEMINI_AUTH as AuthType | undefined);
+  const client = config.getGeminiClient();
+
+  const scheduler = new CoreToolScheduler({
+    toolRegistry: config.getToolRegistry(),
+    approvalMode: config.getApprovalMode(),
+    outputUpdateHandler: () => {},
+    onAllToolCallsComplete: () => {},
+    onToolCallsUpdate: () => {},
+    getPreferredEditor: () => undefined,
+    config,
+  });
+
+  return { client, scheduler, config };
+}
+
+async function main() {
+  const app = express();
+  const server = createServer(app);
+  const wss = new WebSocketServer({ server });
+
+  app.use(express.static('../frontend/dist'));
+
+  wss.on('connection', async (ws) => {
+    const { client, scheduler } = await createSession();
+
+    ws.on('message', async (data) => {
+      const msg = JSON.parse(data.toString());
+      if (msg.type === 'chat_message') {
+        const controller = new AbortController();
+        try {
+          for await (const event of client.sendMessageStream(
+            [{ text: msg.payload.query }],
+            controller.signal,
+          )) {
+            if (event.type === GeminiEventType.ToolCallRequest) {
+              await scheduler.schedule(event.value, controller.signal);
+            } else {
+              ws.send(JSON.stringify(mapEvent(event)));
+            }
+          }
+        } catch (err) {
+          ws.send(
+            JSON.stringify({ type: 'error', payload: { message: String(err) } }),
+          );
+        }
+      } else if (msg.type === 'tool_confirmation') {
+        const { callId, outcome } = msg.payload;
+        await scheduler.handleConfirmationResponse(
+          callId,
+          async () => {},
+          outcome as ToolConfirmationOutcome,
+          new AbortController().signal,
+        );
+      }
+    });
+  });
+
+  server.listen(3000, () => {
+    console.log('BFF listening on port 3000');
+  });
+}
+
+main().catch((err) => {
+  console.error(err);
+});

--- a/web-app/backend/tsconfig.json
+++ b/web-app/backend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "es2020",
+    "target": "es2020",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}

--- a/web-app/frontend/index.html
+++ b/web-app/frontend/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Gemini Web UI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web-app/frontend/package.json
+++ b/web-app/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "gemini-web-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "socket.io-client": "^4.7.4"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "typescript": "^5.3.3",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^5.0.0"
+  }
+}

--- a/web-app/frontend/src/App.tsx
+++ b/web-app/frontend/src/App.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react';
+
+export default function App() {
+  const [messages, setMessages] = useState<string[]>([]);
+  const [input, setInput] = useState('');
+  const [ws, setWs] = useState<WebSocket | null>(null);
+
+  useEffect(() => {
+    const socket = new WebSocket('ws://localhost:3000');
+    socket.onmessage = (event) => {
+      const msg = JSON.parse(event.data);
+      if (msg.type === 'stream_update') {
+        setMessages((prev) => [...prev, msg.payload.textChunk]);
+      }
+    };
+    setWs(socket);
+    return () => socket.close();
+  }, []);
+
+  const send = () => {
+    if (!ws) return;
+    ws.send(JSON.stringify({ type: 'chat_message', payload: { query: input } }));
+    setInput('');
+  };
+
+  return (
+    <div>
+      <div id="messages">
+        {messages.map((m, i) => (
+          <div key={i}>{m}</div>
+        ))}
+      </div>
+      <input value={input} onChange={(e) => setInput(e.target.value)} />
+      <button onClick={send}>Send</button>
+    </div>
+  );
+}

--- a/web-app/frontend/src/main.tsx
+++ b/web-app/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/web-app/frontend/tsconfig.json
+++ b/web-app/frontend/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "useDefineForClassFields": true,
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/web-app/frontend/tsconfig.node.json
+++ b/web-app/frontend/tsconfig.node.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "esnext",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/web-app/frontend/vite.config.ts
+++ b/web-app/frontend/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- add an experimental `web-app` project with a backend and React frontend
- backend exposes a websocket API and loads `@google/gemini-cli-core`
- frontend connects via websocket and streams updates

## Testing
- `npm test --workspaces` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d9869cfe88322afdf05f98edfad2a