### PR TITLE
Fix data integrity and performance in large paste handling

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -112,6 +112,7 @@ const MAX_DISPLAYED_QUEUED_MESSAGES = 3;
 const LARGE_PASTE_THRESHOLD_CHARS = 1000;
 const LARGE_PASTE_THRESHOLD_LINES = 50;
 
+
 interface AppProps {
   config: Config;
   settings: LoadedSettings;
@@ -150,10 +151,6 @@ export const AppWrapper = (props: AppProps) => {
 const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
   const isFocused = useFocus();
   useBracketedPaste();
-  const [pastes, setPastes] = useState<string[]>([]);
-  const handleLargePaste = (pastedText: string) => {
-    setPastes((prevPastes) => [...prevPastes, pastedText]);
-  };
   const [updateInfo, setUpdateInfo] = useState<UpdateObject | null>(null);
   const { stdout } = useStdout();
   const nightly = version.includes('nightly');
@@ -571,7 +568,6 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
     setRawMode,
     isValidPath,
     shellModeActive,
-    onLargePaste: handleLargePaste,
     largePasteThresholdChars: LARGE_PASTE_THRESHOLD_CHARS,
     largePasteThresholdLines: LARGE_PASTE_THRESHOLD_LINES,
   });
@@ -1272,8 +1268,6 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
                   focus={isFocused}
                   vimHandleInput={vimHandleInput}
                   placeholder={placeholder}
-                  pastes={pastes}
-                  setPastes={setPastes}
                 />
               )}
             </>

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -95,6 +95,7 @@ describe('InputPrompt', () => {
 
     mockBuffer = {
       text: '',
+      pastes: new Map(),
       cursor: [0, 0],
       lines: [''],
       setText: vi.fn((newText: string) => {
@@ -187,8 +188,6 @@ describe('InputPrompt', () => {
       inputWidth: 80,
       suggestionsWidth: 80,
       focus: true,
-      pastes: [],
-      setPastes: vi.fn(),
     };
   });
 

--- a/packages/cli/src/ui/hooks/useReverseSearchCompletion.test.tsx
+++ b/packages/cli/src/ui/hooks/useReverseSearchCompletion.test.tsx
@@ -19,7 +19,6 @@ describe('useReverseSearchCompletion', () => {
       viewport: { width: 80, height: 20 },
       isValidPath: () => false,
       onChange: () => {},
-      onLargePaste: () => {},
       largePasteThresholdChars: 1000,
       largePasteThresholdLines: 50,
     });


### PR DESCRIPTION
This commit addresses two issues with the large paste functionality:

1.  A critical data integrity flaw where editing placeholders or using undo/redo could lead to incorrect data being submitted. This is fixed by using unique IDs for each paste and storing the content in a Map that is part of the text buffer's state, making it compatible with undo/redo.

2.  A performance issue in the `isLargePaste` function, which used an inefficient method for counting lines. This has been replaced with a more memory-efficient approach that iterates through the string and counts newline characters directly.